### PR TITLE
Fix missing comma in heuristic output

### DIFF
--- a/doc/main.js
+++ b/doc/main.js
@@ -19,12 +19,12 @@ function buildMultiBezierCode(points, heuristic) {
   if (heuristic) {  // 見やすく出力する
     points_join = "{\n";
     for (let i = 0; i < points_str.length; i += 2) {
-      points_join += "  " + points_str.slice(i, i + 4).join(", ") + "\n";
+      points_join += "  " + points_str.slice(i, i + 4).join(", ") + ",\n";
       i += 4;
       if (i >= points_str.length) {
         break;
       }
-      points_join += "  " + points_str.slice(i, i + 2).join(", ") + "\n";
+      points_join += "  " + points_str.slice(i, i + 2).join(", ") + ",\n";
     }
     points_join += "}";
   } else {  // 1行で出力する
@@ -41,12 +41,12 @@ function buildBezierCodeForTextObject(points, heuristic) {
   if (heuristic) {  // 見やすく出力する
     points_join = "{\n";
     for (let i = 0; i < points_str.length; i += 2) {
-      points_join += "  " + points_str.slice(i, i + 4).join(", ") + "\n";
+      points_join += "  " + points_str.slice(i, i + 4).join(", ") + ",\n";
       i += 4;
       if (i >= points_str.length) {
         break;
       }
-      points_join += "  " + points_str.slice(i, i + 2).join(", ") + "\n";
+      points_join += "  " + points_str.slice(i, i + 2).join(", ") + ",\n";
     }
     points_join += "}";
   } else {  // シンプルに出力する


### PR DESCRIPTION
#1 の修正

`doc/index.html` 内の「マルチベジェ軌道からの変換」「ベジエ曲線エディタ」において「制御点リストに適度に改行を入れる」オプションを有効にしていると、制御点リスト内のカンマが一部足らずそのままでは使用できない文字列が出力されていた。

本修正では、この抜けていたカンマを追加した。